### PR TITLE
Feature/post index/detail

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,3 @@
+class PostsController < ApplicationController
+  
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,3 +1,38 @@
 class PostsController < ApplicationController
-  
+  before_action :authenticate_user!, except: :index
+
+  def index
+    @posts = Post.all.order(created_at: :desc) 
+  end
+
+  def show
+    @post = Post.find(params[:id])
+  end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    current_user.posts.create!(post_params)
+  end
+
+  def edit
+    @post = Post.find(params[:id])
+  end
+
+  def update
+    post = Post.find(params[:id])
+    post.update(post_params)
+  end
+  def destroy
+    post = Post.find(params[:id])
+    post.destroy
+  end
+
+  private
+    def post_params
+      params.require(:post).permit(:title, :content, :image, :aroma)
+    end
+
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,8 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @posts = Post.all.order(created_at: :desc) 
+    aroma_rails = ["フローラル", "ハーバル", "ウッディ", "シトラス", "和風", "スパイシー", "エキゾチック", "その他"]
+    @posts = Post.where(aroma: aroma_rails).order(created_at: :desc) 
   end
 
   def show

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -54,7 +54,7 @@
         </a>
       </div>
       <div class="card">
-      <a href=#>
+      <a href=/posts>
         <img src="https://girlydrop.com/wp-content/uploads/post/p369.jpg" class="card-img-top" alt="...">
         <div class="card-body">
           <h5 class="card-title">everyone&apos;s aroma</h5>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,24 @@
+<div class="wrapper">
+  <div class="contents-title text-center py-3">
+    <h1>everyone&apos;s aroma</h1>
+  </div>
+
+  <div class="row">
+  <%= @posts.each do |post| %>
+      <div class="col-12 col-md-6 col-lg-4 text-card-container">
+        <%= link_to post,class: "card content-card border-dark mb-3", target: :_blank, rel: "noopener noreferrer" do %>
+          <% if post.image? %>
+            <%= image_tag post.image.url %>
+          <% else %>
+            <%= image_tag 'http://design-ec.com/d/e_others_48/l_e_others_484.png'%>
+          <% end %>
+            <div class="card-body text-dark text-card-body">
+              <p class="card-text post-title"> <%= post.title %></p>
+              <%= "投稿者 #{post.user.name}"  %>
+            </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+ 
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class="row">
-  <%= @posts.each do |post| %>
+    <%= @posts.each do |post| %>
       <div class="col-12 col-md-6 col-lg-4 text-card-container">
         <%= link_to post,class: "card content-card border-dark mb-3", target: :_blank, rel: "noopener noreferrer" do %>
           <% if post.image? %>
@@ -20,5 +20,4 @@
       </div>
     <% end %>
   </div>
- 
-</div>
+ </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -14,6 +14,7 @@
           <% end %>
             <div class="card-body text-dark text-card-body">
               <p class="card-text post-title"> <%= post.title %></p>
+              <p>【<%= post.aroma %>】</p>
               <%= "投稿者 #{post.user.name}"  %>
             </div>
         <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,47 @@
+<!-- Card -->
+<div class="card promoting-card">
+
+  <!-- Card content -->
+  <div class="card-body d-flex flex-row">
+
+    <!-- Avatar -->
+    <img src="https://mdbootstrap.com/img/Photos/Avatars/avatar-8.jpg" class="rounded-circle mr-3" height="50px" width="50px" alt="avatar">
+
+    <!-- Content -->
+    <div>
+
+      <!-- Title -->
+      <h4 class="card-title font-weight-bold mb-2">New spicy meals</h4>
+      <!-- Subtitle -->
+      <p class="card-text"><i class="far fa-clock pr-2"></i>07/24/2018</p>
+
+    </div>
+
+  </div>
+
+  <!-- Card image -->
+  <div class="view overlay">
+    <img class="card-img-top rounded-0" src="https://mdbootstrap.com/img/Photos/Horizontal/Food/full page/2.jpg" alt="Card image cap">
+    <a href="#!">
+      <div class="mask rgba-white-slight"></div>
+    </a>
+  </div>
+
+  <!-- Card content -->
+  <div class="card-body">
+
+    <div class="collapse-content">
+
+      <!-- Text -->
+      <p class="card-text collapse" id="collapseContent">Recently, we added several exotic new dishes to our restaurant menu. They come from countries such as Mexico, Argentina, and Spain. Come to us, have some delicious wine and enjoy our juicy meals from around the world.</p>
+      <!-- Button -->
+      <a class="btn btn-flat red-text p-1 my-1 mr-0 mml-1 collapsed" data-toggle="collapse" href="#collapseContent" aria-expanded="false" aria-controls="collapseContent"></a>
+      <i class="fas fa-share-alt text-muted float-right p-1 my-1" data-toggle="tooltip" data-placement="top" title="Share this post"></i>
+      <i class="fas fa-heart text-muted float-right p-1 my-1 mr-3" data-toggle="tooltip" data-placement="top" title="I like it"></i>
+
+    </div>
+
+  </div>
+
+</div>
+<!-- Card -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'home#index'
+
+  resources :posts
+
 end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #13 
- 投稿一覧ページと投稿詳細ページを作成

- 投稿するには「ログイン必須」に変更(authenticate_user!)

- 新規投稿は一覧ページに配置するモーダルから行うようにする(後のajax化のissueで実装)

- 画像がない投稿はデフォルト画像を表示する
- 投稿一覧ページで表示するaromaは以下のものとする
　["フローラル", "ハーバル", "ウッディ", "シトラス", "和風", "スパイシー", "エキゾチック", "その他"]

- 投稿ページからテキスト教材詳細ページに移動できるようにする