### PR TITLE
投稿詳細画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,6 +51,13 @@ main {
   font-size: 25px;
 }
 
+.vertical_like {
+  text-align: center ;
+  margin:100px 100px 0 35px;
+  width: 100px;
+  display: flex;
+}
+
 /* ページネーション部分 */
 .pagination {
   justify-content: center;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,22 @@ main {
   max-width: 1200px;
 } 
 
+/* 投稿詳細部分 */
+.user_info {
+  text-align: center;
+.user_name {
+  margin-top: 20px;
+}
+
+}
+
+.post_title {
+  font-size: 35px;
+}
+.post_content {
+  font-size: 25px;
+}
+
 /* ページネーション部分 */
 .pagination {
   justify-content: center;
@@ -59,6 +75,12 @@ main {
   @extend .alert-danger;
 }  
 
+/* 画像 */
+
+.post_img_full{
+  text-align: center;
+}
+
 .icon_image {
   width: 200px;
   height: 200px;
@@ -67,6 +89,12 @@ main {
   //画像を丸くする
   object-fit: cover;
   //タテヨコ比を変えないままトリミング
+}
+
+.full_image {
+  width: 100%;
+  max-height: 700px;
+
 }
 
 /*

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="comment_form mt-4">
     <%= form_with(model: [post, comment], url: post_comments_path(@post)) do |f| %>
         <%= f.text_area :content, class: "form-control" %>
-        <%= f.submit "送信", class: "btn btn-outline-dark comment-submit float-right mt-3" %>
+        <%= f.submit "送信", class: "btn btn-outline-dark comment-submit  mt-3" %>
     <% end %>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_with(model: [post, comment], url: post_comments_path(@post)) do |f| %>
-    <%= f.text_area :content, class: "form-control" %>
-    <%= f.submit "送信", class: "btn btn-outline-dark comment-submit float-right" %>
-<% end %>
+<div class="comment_form mt-4">
+    <%= form_with(model: [post, comment], url: post_comments_path(@post)) do |f| %>
+        <%= f.text_area :content, class: "form-control" %>
+        <%= f.submit "送信", class: "btn btn-outline-dark comment-submit float-right mt-3" %>
+    <% end %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,7 @@
 
 
         <% if user_signed_in? %>
-          <%= link_to '投稿画面へ', root_path, class: "nav-item nav-link active"%>
+          <%= link_to '投稿一覧へ', posts_path, class: "nav-item nav-link active"%>
           <%= link_to "アカウント編集", edit_user_registration_path ,class: "nav-item nav-link active"%>
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" },class: "nav-item nav-link active" %>
       <% else %>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,16 +1,18 @@
 <% if user_signed_in? %>
 
   <% unless post.like_user(current_user.id).blank? %>
-    <%= link_to post_like_path(post_id: post.id, id: post.likes[0].id), method: :delete, remote: true do %> <%= post.likes.count %>
+    <%= link_to post_like_path(post_id: post.id, id: post.likes[0].id), method: :delete, remote: true do %> 
       <div class="vertical_like">
        <i class="fas fa-heart unlike-btn" ></i>
       </div>
     <% end %>
+    <p><%= post.likes.count %>件のいいね</p>
   <% else %>
-    <%= link_to post_likes_path(post.id), method: :post, remote: true do %> <%= post.likes.count %>
+    <%= link_to post_likes_path(post.id), method: :post, remote: true do %> 
       <div class="vertical_like">
         <i class="far fa-heart like-btn"></i>
       </div>
     <% end %>
+    <p><%= post.likes.count %>件のいいね</p>
   <% end %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,15 +1,31 @@
-<div class="post_detail">
+<div class="post_info">
     <div class="row">
-        <div class="col-4">
-            <% if @post.user.image? %>
-                <img src=<%= @post.user.image %> class = "icon_image">
-            <% else %>
-                <%= image_tag 'profile_default2.jpg' ,class: "icon_image" %>
-            <% end %>
+        <div class="col-4 pl-5">
+            <div class="user_info">
+                <% if @post.user.image? %>
+                    <img src=<%= @post.user.image %> class = "icon_image">
+                <% else %>
+                    <%= image_tag 'profile_default2.jpg' ,class: "icon_image" %>
+                <% end %>
+                <div class="user_name">
+                    <p>【<%= @user.name %>】</p>
+                </div>
+            </div>
         </div>
 
-        <div class="col-8">
-        </div>
+        
+
+    <div class="col-8">
+        <h2 class="post_title"><%= @post.title %></h2>
+        <p>【<%= @post.aroma %>】</p>
+        <p class="post_content"><%= @post.content %></p>
+    </div>
+</div>
+
+    <div class="post_img_full mt-5">
+        <% if @post.image? then %>
+            <%= image_tag @post.image.url class: 'full_image'%>
+        <% end %>
     </div>
 
     <div class="comment-create my-5">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -28,6 +28,10 @@
         <% end %>
     </div>
 
+    <div id="likes_buttons<%= @post.id %>">
+        <%= render partial: 'likes/like', locals: { post: @post, like: @like} %>
+    </div>
+
     <div class="comment-create my-5">
         <h3 class="text-center">コメントを投稿する</h3>
         <%= render partial: 'comments/form', locals: { comment: @comment, post: @post } %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,19 @@
-<h3 class="text-center title">コメント</h3>
-    <div class="comment-create">
-        <h3 class="text-left">レビューを投稿する</h3>
+<div class="post_detail">
+    <div class="row">
+        <div class="col-4">
+            <% if @post.user.image? %>
+                <img src=<%= @post.user.image %> class = "icon_image">
+            <% else %>
+                <%= image_tag 'profile_default2.jpg' ,class: "icon_image" %>
+            <% end %>
+        </div>
+
+        <div class="col-8">
+        </div>
+    </div>
+
+    <div class="comment-create my-5">
+        <h3 class="text-center">コメントを投稿する</h3>
         <%= render partial: 'comments/form', locals: { comment: @comment, post: @post } %>
     </div>
 


### PR DESCRIPTION
close #53 
- 投稿詳細画面に追加要素を加える
- 追加する要素はpostテーブルのtitle、content、image(サムネ加工無し・画像サイズ加工)、userテーブルのname、image、いいね数
  - 上記要素をコメントエリア上部に設置