### PR TITLE
マークダウン機能の修正

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,27 @@
+module MarkdownHelper
+  def markdown(text)
+    markdown = Redcarpet::Markdown.new(html_renderer, markdown_extensions)
+    markdown.render(text).html_safe
+  end
+
+  private
+
+  def html_renderer
+    Redcarpet::Render::HTML
+  end
+
+  def markdown_extensions
+    # 設定の詳細は https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
+    {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -28,7 +28,7 @@ module MarkdownHelper
   def html_renderer
     # ***** 以下を変更 *****
     ::Coderayify.new(
-      filter_html: true,
+      filter_html: false,
       hard_wrap: true,
       link_attributes: { rel: 'nofollow', target: "_blank" }
     )

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -24,4 +24,13 @@ module MarkdownHelper
       strikethrough: true
     }
   end
+
+  def html_renderer
+    # ***** 以下を変更 *****
+    ::Coderayify.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: 'nofollow', target: "_blank" }
+    )
+  end
 end

--- a/lib/autoloads/coderayify.rb
+++ b/lib/autoloads/coderayify.rb
@@ -1,0 +1,34 @@
+class Coderayify < Redcarpet::Render::HTML
+  def block_code(code, language)
+    # コードブロックの拡張子を取得
+    ext = retrieve_extension(language)
+    # 適用するシンタックスハイライトの言語を決める
+    lang = case ext
+           when "rb"
+             :ruby
+           when "yml"
+             :yaml
+           else
+             ext.to_sym
+           end
+    CodeRay.scan(code, lang).div
+  end
+
+  private
+
+  # 拡張子を取得するメソッド
+  def retrieve_extension(language)
+    if language.blank?
+      # コードブロックの開始宣言で「```」の後に拡張子が与えられていない場合は md 形式とみなす
+      "md"
+    elsif language.include?(":")
+      # コードブロックの開始宣言が「```rb:sample.rb」の場合は rb 形式とみなす
+      language.split(':')[0]
+    elsif language.include?(".")
+      # コードブロックの開始宣言が「```sample.rb」の場合は rb 形式とみなす
+      language.split('.')[-1]
+    else
+      language
+    end
+  end
+end


### PR DESCRIPTION
close #83 
- htmlのフィルターをfalseに変えてマークダウン内でもhtmlを表現できるようにする
- applicationヘルパーにあるマークダウンのメソッドを専用のヘルパーを用意して記述を移す
- シンタックスハイライトのメソッドに関しても上記と同様の作業を行う