### PR TITLE
数点のレイアウト変更

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@ body {
 }
 
 main {
+  min-height: 100%;
   padding-top: 50px;
   padding-bottom: 100px;
   background-color: #FFFAF0;

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -4,7 +4,7 @@
 }
 
 .full_image {
-  width: 100%;
+  width: 70%;
   max-height: 600px;
 }
 
@@ -248,8 +248,13 @@ a:hover{
   font-size: 35px;
   overflow-wrap: break-word;
 }
-.post_content {
-  font-size: 25px;
+.post-article {
+  text-align: center;
+  p {
+    font-size: 25px;
+    padding: 10px 200px;
+    overflow-wrap:  break-word;
+  }
 }
 
 .content-entry {

--- a/app/assets/stylesheets/tips.scss
+++ b/app/assets/stylesheets/tips.scss
@@ -63,3 +63,7 @@
     font-size: 20px;
     font-family: 'Kosugi Maru', sans-serif;
 }
+
+.tip-container {
+  margin-top: 80px;
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -42,5 +42,5 @@
   <% end %>
 
   <hr class="my-3">
-  <%= link_to "トップページ", root_path, class:"btn btn-info btn-block" %>
+  <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -39,5 +39,5 @@
 
 
 <hr class="my-3">
-  <%= link_to "トップページ", root_path, class:"btn btn-info btn-block" %>
+  <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -28,6 +28,6 @@
    
 
 
-<hr class="my-3">
-  <%= link_to "トップページ", root_path, class:"btn btn-info btn-block" %>
-</div>
+  <hr class="my-3">
+    <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
+  </div>

--- a/app/views/home/diagnoses.html.erb
+++ b/app/views/home/diagnoses.html.erb
@@ -232,5 +232,5 @@
       
 <hr class="my-3">
   <div class='button-group'>
-    <%= link_to "トップページ", root_path, class:"btn btn-outline-primary btn-block" %>
+    <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -66,3 +66,8 @@
       </div>
     </div>
   </div>
+
+  <hr class="my-3">
+  <div class=button-group>
+      <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
+  </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -26,7 +26,7 @@
     </div>
 </div>
 
-<div class=post_content>
+<div class="post-article">
     <p><%= @post.content %></p>
 </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -53,5 +53,5 @@
 <hr class="my-3">
 <div class=button-group>
     <%= link_to "投稿一覧へ", posts_path, class:"btn btn-outline-primary btn-block" %>
-    <%= link_to "トップページ", root_path, class:"btn btn-outline-primary btn-block" %>
+    <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
 </div>

--- a/app/views/tips/index.html.erb
+++ b/app/views/tips/index.html.erb
@@ -27,3 +27,8 @@
 <div class='content-footer'>
   <p>新しいコンテンツも追加予定です！</p>
 </div>
+
+<hr class="my-3">
+  <div class='button-group'>
+    <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
+  </div>

--- a/app/views/tips/show.html.erb
+++ b/app/views/tips/show.html.erb
@@ -4,6 +4,13 @@
     <h2 class='page-title'>aroma tips</h2>
     <p>生活に役立つアロマの豆知識を発信します</p>
 </div>
+<div class="tip-container">
+    <h1 class="text-center">〜<%= @tip.title %>〜</h1>
+    <p><%= markdown(@tip.article) %></p> 
+</div>
 
-<h1><%= @tip.title %></h1>
-<p><%= markdown(@tip.article) %></p> 
+<hr class="my-3">
+  <div class='button-group'>
+    <%= link_to "記事一覧へ", tips_path, class:"btn btn-outline-primary btn-block" %>
+    <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
+  </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,4 +77,13 @@
         </div>
       <% end %>
     </div>
+  </div>
+  
+  <hr class="my-3">
+  <div class=button-group>
+    <%= link_to "投稿一覧へ", posts_path, class:"btn btn-outline-primary btn-block" %>
+    <%= link_to "トップページへ", root_path, class:"btn btn-outline-primary btn-block" %>
+  </div> 
+
+    
     


### PR DESCRIPTION
- 投稿詳細画面
  - 本文を中央寄せに
  - 画像のサイズをやや小さくする
  - 混同を避けるためクラス名の変更

- ログイン画面
  - 無駄なページ下部の余白を削除
  - リンクボタンのレイアウトを全ページで統一する