### PR TITLE
ページネーション関連のバグの解消

### DIFF
--- a/app/admin/comments.rb
+++ b/app/admin/comments.rb
@@ -1,0 +1,14 @@
+ActiveAdmin.register Comment, :as => "PostComment" do
+
+  permit_params :user_id, :post_id, :content
+
+  index do
+    selectable_column
+    id_column
+    column :user_id
+    column :post_id
+    column :content
+    actions
+  end
+
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,10 +3,9 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[destroy]
 
   PER_PAGE = 5
-  Aroma_Rails = ["フローラル", "ハーバル", "ウッディ", "シトラス", "和の香り", "スパイシー", "エキゾチック", "その他"]
 
   def index
-    @posts = Post.where(aroma: Aroma_Rails).order(created_at: :desc)
+    @posts = Post.all.order(created_at: :desc)
     @posts = @posts.page(params[:page]).per(PER_PAGE)
     @post = Post.new
   end
@@ -24,14 +23,14 @@ class PostsController < ApplicationController
 
   def create
     @post = Post.create!(post_params)
-    @posts = Post.where(aroma: Aroma_Rails).order(created_at: :desc)
+    @posts = Post.all.order(created_at: :desc)
     @posts = @posts.page(params[:page]).per(PER_PAGE)
   end
 
   def destroy
     @post.destroy!
 
-    @posts = Post.where(aroma: Aroma_Rails).order(created_at: :desc)
+    @posts = Post.all.order(created_at: :desc)
     @posts = @posts.page(params[:page]).per(PER_PAGE)
 
     @user = User.find_by(id: @post.user_id)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, except: :index
   before_action :set_post, only: %i[destroy]
 
-  PER_PAGE = 5
+  PER_PAGE = 1
   Aroma_Rails = ["フローラル", "ハーバル", "ウッディ", "シトラス", "和の香り", "スパイシー", "エキゾチック", "その他"]
 
   def index
@@ -30,6 +30,8 @@ class PostsController < ApplicationController
 
   def destroy
     @post.destroy!
+    @posts = Post.where(aroma: Aroma_Rails).order(created_at: :desc)
+    @posts = @posts.page(params[:page]).per(PER_PAGE)
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,10 +3,10 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[destroy]
 
   PER_PAGE = 5
+  Aroma_Rails = ["フローラル", "ハーバル", "ウッディ", "シトラス", "和の香り", "スパイシー", "エキゾチック", "その他"]
 
   def index
-    aroma_rails = ["フローラル", "ハーバル", "ウッディ", "シトラス", "和の香り", "スパイシー", "エキゾチック", "その他"]
-    @posts = Post.where(aroma: aroma_rails).order(created_at: :desc)
+    @posts = Post.where(aroma: Aroma_Rails).order(created_at: :desc)
     @posts = @posts.page(params[:page]).per(PER_PAGE)
     @post = Post.new
   end
@@ -24,7 +24,8 @@ class PostsController < ApplicationController
 
   def create
     @post = Post.create!(post_params)
-    @posts = Post.all.order(created_at: :desc) 
+    @posts = Post.where(aroma: Aroma_Rails).order(created_at: :desc)
+    @posts = @posts.page(params[:page]).per(PER_PAGE)
   end
 
   def destroy

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, except: :index
   before_action :set_post, only: %i[destroy]
 
-  PER_PAGE = 1
+  PER_PAGE = 5
   Aroma_Rails = ["フローラル", "ハーバル", "ウッディ", "シトラス", "和の香り", "スパイシー", "エキゾチック", "その他"]
 
   def index

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,8 +30,15 @@ class PostsController < ApplicationController
 
   def destroy
     @post.destroy!
+
     @posts = Post.where(aroma: Aroma_Rails).order(created_at: :desc)
     @posts = @posts.page(params[:page]).per(PER_PAGE)
+
+    @user = User.find_by(id: @post.user_id)
+    @my_posts = @user.posts.order(created_at: :desc)
+    @my_posts = @my_posts.page(params[:page]).per(PER_PAGE)
+
+    @like_posts = @user.like_posts.page(params[:page]).per(PER_PAGE)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,10 @@
 class UsersController < ApplicationController
+  PER_PAGE = 5
+
   def show
     @user = User.find(params[:id])
     @posts = @user.posts.order(created_at: :desc)
+    @posts = @posts.page(params[:page]).per(PER_PAGE)
     @likes = Like.where(user_id: @user.id).order(created_at: :desc)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,6 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @posts = @user.posts.order(created_at: :desc)
     @posts = @posts.page(params[:page]).per(PER_PAGE)
-    @likes = Like.where(user_id: @user.id).order(created_at: :desc)
+    @like_posts = @user.like_posts.page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :like_posts, through: :likes, source: :post
+
   mount_uploader :image, ImageUploader
 
   validates :name, presence: true

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -40,3 +40,5 @@
     </span>
   </div>
 <% end %>
+
+  <%= paginate posts %>

--- a/app/views/posts/_tabs.html.erb
+++ b/app/views/posts/_tabs.html.erb
@@ -1,0 +1,15 @@
+<div class="tabs">
+  <input id="all" type="radio" name="tab_item" checked>
+  <label class="tab_item" for="all">投稿した記事</label>
+
+  <input id="like" type="radio" name="tab_item">
+  <label class="tab_item" for="like">いいねした記事</label>
+
+    <div class="tab_content" id="all_content">
+      <%= render 'posts/posts' , posts: @posts %>
+    </div>
+
+    <div class="tab_content" id="like_content">
+      <%= render 'posts/posts' , posts: @like_posts %>
+    </div>
+</div>

--- a/app/views/posts/destroy.js.erb
+++ b/app/views/posts/destroy.js.erb
@@ -1,1 +1,1 @@
-document.getElementById('post-<%= @post.id %>').outerHTML = ''
+$('.posts').html("<%= escape_javascript(render 'posts', posts: @posts) %>")

--- a/app/views/posts/destroy.js.erb
+++ b/app/views/posts/destroy.js.erb
@@ -1,1 +1,3 @@
 $('.posts').html("<%= escape_javascript(render 'posts', posts: @posts) %>")
+$('#all_content').html("<%= escape_javascript(render 'posts', posts: @my_posts) %>")
+$('#like_content').html("<%= escape_javascript(render 'posts', posts: @like_posts) %>")

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,6 @@
   <div class='main-contents'>
     <div class="posts">
       <%= render 'posts', posts: @posts %>
-      <%= paginate @posts %>
     </div>
     <aside>
       <%= render 'side-bar' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,49 +36,9 @@
     </div>
 
     <div class="tab_content" id="like_content">
-       <% @likes.each do |like| %>
-        <div class="card mb-1">
-          <%= link_to @post do %>
-            <div class="card-body">
-              <div class="icon_space">
-                    <% if like.post.user.image? %>
-                      <img src=<%= like.post.user.image %> class = "icon_image">
-                    <% else %>
-                      <%= image_tag 'profile_default2.jpg' ,class: "icon_image" %>
-                    <% end %>
-              </div>
-              <div class='text_space'>
-                    <p class='card-text'><%= like.post.title %></p>
-                    <p>【<%= like.post.aroma %>】</p>
-                    <p class='text_content'><%= like.post.content %></p>
-              </div>
-
-                <div class='thumbnail_space'>
-                  <div class="like_space">
-                    <i class="far fa-comment-dots home-icon"></i> <%= like.post.comments.count %>
-                    <i class="fas fa-heart home-icon"></i> <%= like.post.likes.count %>
-                  </div>
-
-                  <% if like.post.image? %>
-                      <%= image_tag like.post.image.thumb.url ,class: 'thumb-image'%>
-                  <% else %>
-                      <%= image_tag 'noimage.png',class: 'noimage' %>
-                  <% end %>
-                </div>
-            </div>
-          <% end %>
-              <span class="text-muted pl-2 d-inline-flex">
-                <i class='fas fa-clock home-icon mr-1'></i> <%= time_ago_in_words(like.post.created_at) %>前
-                <% if like.post.user == current_user %>
-                  <%= link_to post_path(like.post),class: 'text-danger', method: :delete, data: { confirm: '削除しますか?', remote: true } do %>
-                    <i class="fas fa-trash home-icon ml-2"></i> 削除 
-                  <% end %>
-                <% end %>
-              </span>
-          </div>
-        <% end %>
-      </div>
+      <%= render 'posts/posts' , posts: @like_posts %>
     </div>
+   
   
     <hr class="my-3">
     <div class=button-group>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,20 +24,7 @@
 
 
 
-<div class="tabs">
-  <input id="all" type="radio" name="tab_item" checked>
-  <label class="tab_item" for="all">投稿した記事</label>
-
-  <input id="like" type="radio" name="tab_item">
-  <label class="tab_item" for="like">いいねした記事</label>
-
-    <div class="tab_content" id="all_content">
-      <%= render 'posts/posts' , posts: @posts %>
-    </div>
-
-    <div class="tab_content" id="like_content">
-      <%= render 'posts/posts' , posts: @like_posts %>
-    </div>
+  <%= render 'posts/tabs' %>
    
   
     <hr class="my-3">

--- a/db/migrate/20210604111150_remove_post_id_from_likes.rb
+++ b/db/migrate/20210604111150_remove_post_id_from_likes.rb
@@ -1,0 +1,5 @@
+class RemovePostIdFromLikes < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :likes, :post_id, :string
+  end
+end

--- a/db/migrate/20210604111222_add_post_id_to_like.rb
+++ b/db/migrate/20210604111222_add_post_id_to_like.rb
@@ -1,0 +1,5 @@
+class AddPostIdToLike < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :likes, :post, foreign_key: true
+  end
+end

--- a/db/migrate/20210604132924_remove_user_id_from_posts.rb
+++ b/db/migrate/20210604132924_remove_user_id_from_posts.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromPosts < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :posts, :user_id, :string
+  end
+end

--- a/db/migrate/20210604133036_add_user_id_to_post.rb
+++ b/db/migrate/20210604133036_add_user_id_to_post.rb
@@ -1,0 +1,5 @@
+class AddUserIdToPost < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :posts, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20210604134057_remove_user_id_from_comments.rb
+++ b/db/migrate/20210604134057_remove_user_id_from_comments.rb
@@ -1,0 +1,6 @@
+class RemoveUserIdFromComments < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :comments, :user_id, :integer
+    remove_column :comments, :post_id, :integer
+  end
+end

--- a/db/migrate/20210604134148_add_user_id_to_comment.rb
+++ b/db/migrate/20210604134148_add_user_id_to_comment.rb
@@ -1,0 +1,6 @@
+class AddUserIdToComment < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :comments, :user, foreign_key: true
+    add_reference :comments, :post, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_04_111222) do
+ActiveRecord::Schema.define(version: 2021_06_04_133036) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,9 +62,10 @@ ActiveRecord::Schema.define(version: 2021_06_04_111222) do
     t.string "aroma"
     t.text "content"
     t.string "image"
-    t.string "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "tips", force: :cascade do |t|
@@ -90,4 +91,5 @@ ActiveRecord::Schema.define(version: 2021_06_04_111222) do
   end
 
   add_foreign_key "likes", "posts"
+  add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_04_133036) do
+ActiveRecord::Schema.define(version: 2021_06_04_134148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,10 +43,12 @@ ActiveRecord::Schema.define(version: 2021_06_04_133036) do
 
   create_table "comments", force: :cascade do |t|
     t.text "content"
-    t.integer "user_id"
-    t.integer "post_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
@@ -90,6 +92,8 @@ ActiveRecord::Schema.define(version: 2021_06_04_133036) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_072105) do
+ActiveRecord::Schema.define(version: 2021_06_04_111222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,10 +51,10 @@ ActiveRecord::Schema.define(version: 2021_05_31_072105) do
 
   create_table "likes", force: :cascade do |t|
     t.string "user_id"
-    t.string "post_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
+    t.bigint "post_id"
+    t.index ["post_id"], name: "index_likes_on_post_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -89,4 +89,5 @@ ActiveRecord::Schema.define(version: 2021_05_31_072105) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "likes", "posts"
 end


### PR DESCRIPTION
close #96 
- 投稿一覧画面から投稿するとページネーションが適用されなくなるバグを解消
- 投稿一覧画面から削除機能を使うと新しく一覧画面が読み込まれないバグを解消
- 投稿一覧、マイページから削除機能を使うとページネーションが適用されなくなるバグを解消
- Commentテーブル、Likesテーブルに外部キー制約を付けるのを失念していたため急遽対応する