### PR TITLE
Postテーブルaromaカラムに対する変更

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -353,3 +353,28 @@ input[name="tab_item"] {
 .form-content {
   min-height: 300px;
 }
+
+.floral{
+  background-color: #FFCCFF;
+}
+.citrus {
+  background-color: #FFFF99;
+}
+.herbal{
+  background-color: #AEFFBD;
+}
+.woody{
+  background-color: #FFAD90;
+}
+.spicy{
+  background-color: #DB7093;
+}
+.japanese{
+  background-color: #66CDAA;
+}
+.exotic{
+  background-color: #D0B0FF;
+}
+.other{
+  background-color: #DCDCDC;
+}

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -234,6 +234,9 @@ a:hover{
   display: flex;
   .post_entry {
     width: 80%;
+    p {
+      font-size: 18px;
+    }
   }
 }
 .user_info {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,6 +45,26 @@ module ApplicationHelper
     markdown.render(text).html_safe
   end
 
+  def translation_class_name(aroma)
+    if aroma == "フローラル"
+      aroma.gsub(aroma,"floral")
+    elsif aroma == "ハーバル"
+      aroma.gsub(aroma,"herbal")
+    elsif aroma == "ウッディ"
+      aroma.gsub(aroma,"woody")
+    elsif aroma == "シトラス"
+      aroma.gsub(aroma,"citrus")
+    elsif aroma == "スパイシー"
+      aroma.gsub(aroma,"spicy")
+    elsif aroma == "和の香り"
+      aroma.gsub(aroma,"japanese")
+    elsif aroma == "エキゾチック"
+      aroma.gsub(aroma,"exotic")
+    elsif aroma == "その他"
+      aroma.gsub(aroma,"other")
+    end
+  end
+
 
   def max_width
     if devise_controller?

--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -8,7 +8,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="exampleModalLabel">新規投稿</h5>
+          <h5 class="modal-title font-weight-bold" id="exampleModalLabel">新規投稿</h5>
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
@@ -17,22 +17,22 @@
             
         
         <%= form_for @post, remote: true do |f| %>    
-          <div class="modal-body">
+          <div class="modal-body font-weight-bold">
             <div class="form-group">
               <%= f.label :title, "タイトル(30字以内)" %>
               <%= f.text_field :title, class:"form-control",required: true ,maxlength:"30" %>
             </div>
             
-            <div class="form-group">
+            <div class="form-group d-flex">
               <%= f.select :aroma, [["フローラル", "フローラル"], ["ハーバル", "ハーバル"], ["ウッディ", "ウッディ"],["シトラス", "シトラス"],["和の香り", "和の香り"],["スパイシー", "スパイシー"],["エキゾチック", "エキゾチック"],["その他", "その他"]],{ :include_blank => "選択(必須)▼" },:required => true, :id =>"aromaselector" %>
-              <div class="result">
-                <div id="フローラル" class="aromas フローラル">甘く華やかな香りが特徴の癒やし系</div>
-                <div id="ハーバル" class="aromas ハーバル"> 少し薬草の香りがするスッキリ系</div>
-                <div id="ウッディ" class="aromas ウッディ"> 森の中に来たような落ち着く香りの安定系</div>
-                <div id="シトラス" class="aromas シトラス"> 爽やかな香りが弾ける元気系</div>
-                <div id="和の香り" class="aromas 和の香り"> どこか懐かしい香りのするほっこり系</div>
-                <div id="スパイシー" class="aromas スパイシー"> インパクト強めで刺激的な個性系</div>
-                <div id="エキゾチック" class="aromas エキゾチック"> オリエンタルで個性的な官能系</div>
+              <div class="result ml-2 font-weight-bold">
+                <div id="フローラル" class="aromas フローラル">甘く華やかな香りが特徴の癒やし系です</div>
+                <div id="ハーバル" class="aromas ハーバル"> 少し薬草の香りがするスッキリ系です</div>
+                <div id="ウッディ" class="aromas ウッディ"> 森にも似た落ち着く香りの安定系です</div>
+                <div id="シトラス" class="aromas シトラス"> 爽やかな香りが弾ける元気系です</div>
+                <div id="和の香り" class="aromas 和の香り"> どこか懐かしい香りのするほっこり系です</div>
+                <div id="スパイシー" class="aromas スパイシー"> インパクト強めで刺激的な個性系です</div>
+                <div id="エキゾチック" class="aromas エキゾチック"> オリエンタルで個性的な官能系です</div>
               </div>
             </div>
 

--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -1,0 +1,47 @@
+<div class="modal-area">
+    <button type="button" class="fixed_btn" data-toggle="modal" data-target="#exampleModal">
+      <i class="far fa-comment-dots fa-2x"></i>  投稿する
+    </button>
+  </div>
+
+  <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLabel">新規投稿</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+
+            
+        
+        <%= form_for @post, remote: true do |f| %>    
+          <div class="modal-body">
+            <div class="form-group">
+              <%= f.label :title, "タイトル(30字以内)" %>
+              <%= f.text_field :title, class:"form-control",required: true ,maxlength:"30" %>
+            </div>
+            
+            <div class="form-group">
+              <%= f.select :aroma, [["フローラル", "フローラル"], ["ハーバル", "ハーバル"], ["ウッディ", "ウッディ"],["シトラス", "シトラス"],["和の香り", "和の香り"],["スパイシー", "スパイシー"],["エキゾチック", "エキゾチック"],["その他", "その他"]],{ :include_blank => "選択(必須)▼" },:required => true %>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :content, "本文" %>
+              <%= f.text_area :content, class:"form-control form-content",required: true %>
+            </div>
+
+            <div class="form-group">
+              <%= f.label :image,"画像"%><br>
+              <%= f.file_field :image, accept: "image/png,image/jpeg,image/gif" %>
+            </div> 
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+            <%= f.submit "投稿する", class:"btn btn-primary" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>

--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -24,7 +24,16 @@
             </div>
             
             <div class="form-group">
-              <%= f.select :aroma, [["フローラル", "フローラル"], ["ハーバル", "ハーバル"], ["ウッディ", "ウッディ"],["シトラス", "シトラス"],["和の香り", "和の香り"],["スパイシー", "スパイシー"],["エキゾチック", "エキゾチック"],["その他", "その他"]],{ :include_blank => "選択(必須)▼" },:required => true %>
+              <%= f.select :aroma, [["フローラル", "フローラル"], ["ハーバル", "ハーバル"], ["ウッディ", "ウッディ"],["シトラス", "シトラス"],["和の香り", "和の香り"],["スパイシー", "スパイシー"],["エキゾチック", "エキゾチック"],["その他", "その他"]],{ :include_blank => "選択(必須)▼" },:required => true, :id =>"aromaselector" %>
+              <div class="result">
+                <div id="フローラル" class="aromas フローラル">甘く華やかな香りが特徴の癒やし系</div>
+                <div id="ハーバル" class="aromas ハーバル"> 少し薬草の香りがするスッキリ系</div>
+                <div id="ウッディ" class="aromas ウッディ"> 森の中に来たような落ち着く香りの安定系</div>
+                <div id="シトラス" class="aromas シトラス"> 爽やかな香りが弾ける元気系</div>
+                <div id="和の香り" class="aromas 和の香り"> どこか懐かしい香りのするほっこり系</div>
+                <div id="スパイシー" class="aromas スパイシー"> インパクト強めで刺激的な個性系</div>
+                <div id="エキゾチック" class="aromas エキゾチック"> オリエンタルで個性的な官能系</div>
+              </div>
             </div>
 
             <div class="form-group">
@@ -45,3 +54,13 @@
       </div>
     </div>
   </div>
+
+  <script>
+    $(function() {
+    $('.aromas').hide();
+    $('#aromaselector').change(function(){
+      $('.aromas').hide();
+      $('#' + $(this).val()).show();
+      });
+    });
+  </script>

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -12,7 +12,7 @@
         
         <div class='text_space'>
           <p class='card-text'><%= post.title %></p>
-          <p class='<%= translation_class_name(post.aroma) %>'>【<%= post.aroma %>】</p>
+          <p class='<%= translation_class_name(post.aroma) %> badge badge-pill'><%= post.aroma %></p>
           <p class='text_content'><%= post.content %></p>
         </div>
 

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -12,7 +12,7 @@
         
         <div class='text_space'>
           <p class='card-text'><%= post.title %></p>
-          <p>【<%= post.aroma %>】</p>
+          <p class='<%= translation_class_name(post.aroma) %>'>【<%= post.aroma %>】</p>
           <p class='text_content'><%= post.content %></p>
         </div>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -21,53 +21,7 @@
     </aside>
   </div>
   
-  <div class="modal-area">
-    <button type="button" class="fixed_btn" data-toggle="modal" data-target="#exampleModal">
-      <i class="far fa-comment-dots fa-2x"></i>  投稿する
-    </button>
-  </div>
-
-  <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="exampleModalLabel">新規投稿</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-
-            
-        
-        <%= form_for @post, remote: true do |f| %>    
-          <div class="modal-body">
-            <div class="form-group">
-              <%= f.label :title, "タイトル(30字以内)" %>
-              <%= f.text_field :title, class:"form-control",required: true ,maxlength:"30" %>
-            </div>
-            
-            <div class="form-group">
-              <%= f.select :aroma, [["フローラル", "フローラル"], ["ハーバル", "ハーバル"], ["ウッディ", "ウッディ"],["シトラス", "シトラス"],["和の香り", "和の香り"],["スパイシー", "スパイシー"],["エキゾチック", "エキゾチック"],["その他", "その他"]],{ :include_blank => "選択(必須)▼" },:required => true %>
-            </div>
-
-            <div class="form-group">
-              <%= f.label :content, "本文" %>
-              <%= f.text_area :content, class:"form-control form-content",required: true %>
-            </div>
-
-            <div class="form-group">
-              <%= f.label :image,"画像"%><br>
-              <%= f.file_field :image, accept: "image/png,image/jpeg,image/gif" %>
-            </div> 
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
-            <%= f.submit "投稿する", class:"btn btn-primary" %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  </div>
+  <%= render 'modal' %>
 
   <hr class="my-3">
   

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,7 +22,7 @@
 
     <div class='post_entry'>
         <h2 class="post_title"><%= @post.title %></h2>
-        <p>香りのタイプ【<%= @post.aroma %>】</p>
+        <p class='<%= translation_class_name(@post.aroma) %> badge badge-pill'><%= @post.aroma %></p>
     </div>
 </div>
 


### PR DESCRIPTION
close #99 
- モーダル部分を部分テンプレート化
- モーダルウィンドウにアロマの説明文を追加、セレクトフォームに合わせて表示
- クラス名を変更するヘルパーを作成し一覧画面で色分け
- カテゴリ名をバッジにして表示
