### PR TITLE
各機能のヘッダーの修正

### DIFF
--- a/app/assets/stylesheets/diagnoses.scss
+++ b/app/assets/stylesheets/diagnoses.scss
@@ -168,8 +168,10 @@ ul {
 }
 
 .textBox {
+  display: flex;
   span {
     font-weight: bold;
+    margin-right: auto;
   }
 }
 
@@ -194,11 +196,5 @@ ul {
   .result {
     margin: 20px 0;
     width: 100%;
-  }
-}
-
-@media screen and (min-width: 950px) {
-  .br-sp {
-    display: none;
   }
 }

--- a/app/assets/stylesheets/diagnoses.scss
+++ b/app/assets/stylesheets/diagnoses.scss
@@ -150,11 +150,12 @@ ul {
 .big-bg .page-title {
   font-family: 'Londrina Shadow', cursive;
   font-size: 50px;
-  color: #000;
+  color: #FFFFFF;
   letter-spacing: 0.1em;
   font-weight: bold;
   padding-top: 80px;
   text-align: center;
+  text-shadow: 1px 2px 3px #009966; 
 }
 
 .big-bg p {
@@ -162,7 +163,8 @@ ul {
   font-weight: bold;
   margin: 10px 0 0;
   text-align: center;
-  color: #111111;
+  color: #fff;
+  text-shadow: 1px 2px 3px #009966; 
 }
 
 .textBox {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -82,19 +82,21 @@
 .post-content .page-title {
   font-family: 'Londrina Shadow', cursive;
   font-size: 50px;
-  color: #000;
+  color: #fff;
   letter-spacing: 0.1em;
   font-weight: bold;
   padding-top: 80px;
   text-align: center;
+  text-shadow: 1px 2px 3px #009966; 
 }
 
 .post-content p {
   font-weight: bold;
   font-size: 25px;
-  color: #000;
+  color: #fff;
   margin: 10px 0 0;
   text-align: center;
+  text-shadow: 1px 2px 3px #009966; 
 }
 
 .fixed_btn {

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -423,7 +423,7 @@ input[name="tab_item"] {
   }
 
   .main-contents {
-    flex-direction: column-reverse;
+    flex-direction: column;
     width: 100%;
   }
 

--- a/app/assets/stylesheets/tips.scss
+++ b/app/assets/stylesheets/tips.scss
@@ -12,11 +12,12 @@
 .big-bg .page-title {
   font-family: 'Londrina Shadow', cursive;
   font-size: 50px;
-  color: #000;
+  color: #FFF;
   letter-spacing: 0.1em;
   font-weight: bold;
   padding-top: 80px;
   text-align: center;
+  text-shadow: 1px 2px 3px #009966; 
 }
 
 .big-bg p {
@@ -24,7 +25,8 @@
   font-weight: bold;
   margin: 10px 0 0;
   text-align: center;
-  color: #111111;
+  color: #FFF;
+  text-shadow: 1px 2px 3px #009966; 
 }
 
 .text-card-container {

--- a/app/views/home/diagnoses.html.erb
+++ b/app/views/home/diagnoses.html.erb
@@ -7,9 +7,9 @@
 
 <div id="wrapper">
   <%= image_tag 'finder-bg' ,class: 'finder-bg' %>
-  <ul class="questions text-center">
-    <h1 class="title">Questions</h1>
-    <p>(今のご気分でお答えください)</p>
+  <ul class="questions">
+    <h1 class="title text-center">Questions</h1>
+    <p class="text-center">(今のご気分でお答えください)</p>
 
     <li class="textBox">
       <span class="text">Q1. 気分が落ち込んでいる</span>
@@ -52,7 +52,7 @@
     </li>
 
     <li class="textBox">
-      <span class="text">Q6.お肌のトラブルに悩んでいる</span><br class="br-sp">
+      <span class="text">Q6.お肌のトラブルがある</span>
       <label class="yes"><input class="typeC typeG" name="q06" type="radio">YES
       </label>
       <label class="no"><input class="typeA typeB" name="q06" type="radio">NO
@@ -100,7 +100,7 @@
     </li>
 
     <li class="textBox">
-      <span class="text">Q12.風邪はいつも喉からくる</span><br class="br-sp">
+      <span class="text">Q12.風邪はいつも喉からくる</span>
       <label class="yes"><input class="typeH typeI" name="q12" type="radio">YES
       </label>
       <label class="no"><input name="q12" type="radio">NO
@@ -108,7 +108,7 @@
     </li>
 
     <li class="textBox">
-      <span class="text">Q13. 家にいても仕事のことが忘れられない</span><br class="br-sp">
+      <span class="text">Q13. 仕事のことが忘れられない</span>
       <label class="yes"><input class="typeF typeJ" name="q13" type="radio">YES
       </label>
       <label class="no"><input class="typeA typeC" name="q13" type="radio">NO
@@ -123,7 +123,9 @@
       </label>
     </li>
 
-    <button class="btn btn-radius-solid btn--shadow w-50 mt-2" id="finder-btn">Check!</button>
+    <div class="text-center">
+      <button class="btn btn-radius-solid btn--shadow w-50 mt-2" id="finder-btn">Check!</button>
+    </div>
   </ul>
 </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,10 +1,4 @@
 <%= stylesheet_link_tag 'posts', media: 'all', 'data-turbolinks-track': 'reload' %>
-<div id="wrapper" class='big-bg'>
-    <div class="post-content ">
-        <h2 class='page-title'>everyone&apos;s aroma</h2>
-        <p>癒やしの時間をシェアしませんか?</p>
-    </div>
-</div>
 
 <div class="post_info">
     <div class="user_info">

--- a/app/views/tips/show.html.erb
+++ b/app/views/tips/show.html.erb
@@ -1,9 +1,5 @@
 <%= stylesheet_link_tag 'tips', media: 'all', 'data-turbolinks-track': 'reload' %>
 
-<div class='big-bg'>
-  <h2 class='page-title'>aroma tips</h2>
-  <p>生活に役立つアロマの豆知識を発信します</p>
-</div>
 <div class="tip-container">
   <h1 class="text-center">〜<%= @tip.title %>〜</h1>
   <p><%= markdown(@tip.article).html_safe %></p>


### PR DESCRIPTION
close #130 
- 各機能のヘッダーを詳細ページでは表示しないようにする
- 各機能のヘッダーの文字が読みにくいためレイアウト修正
- 投稿画面のスマホ版の配置を変更する
- 診断機能のラジオボタンの位置を揃える